### PR TITLE
feat: Add ability to convert to double

### DIFF
--- a/ConsoleExtProgram/Program.cs
+++ b/ConsoleExtProgram/Program.cs
@@ -9,6 +9,9 @@ IWriteData write = new WriteDataToConsole();
 IReadData read = new ReadDataFromConsole();
 string inputString = read.ReadData();
 
+// *************Convert********** //
+// string.ConvertToInt();         //
+// string.ConvertToDouble();      //
 
 // ****************************** //
 // Convert a string to an integer //

--- a/ConsoleExtension.Library/Converters/ConvertStringToDouble.cs
+++ b/ConsoleExtension.Library/Converters/ConvertStringToDouble.cs
@@ -1,0 +1,20 @@
+﻿using ConsoleExtension.Library.Result;
+
+namespace ConsoleExtension.Library.Converters
+{
+    public static class ConvertStringToDouble
+    {
+        public static IResult<double> ConvertToDouble(this string inputString, double defaultValue = 0.0)
+        {
+            if (double.TryParse(inputString, out double result))
+            {
+                return new ResultSuccess<double>(result);
+            }
+
+            string errorMessage = $"Could not convert the string [{inputString}] to a double. It's not in a double-format.";
+            IResult<double> FailedResult = new ResultFailed<double>(defaultValue);
+            FailedResult.AddResultMessage(errorMessage);
+            return FailedResult;
+        }
+    }
+}

--- a/ConsoleExtension.Library/Converters/ConvertStringToDouble.cs
+++ b/ConsoleExtension.Library/Converters/ConvertStringToDouble.cs
@@ -1,12 +1,18 @@
 ﻿using ConsoleExtension.Library.Result;
+using System.Globalization;
 
 namespace ConsoleExtension.Library.Converters
 {
     public static class ConvertStringToDouble
     {
-        public static IResult<double> ConvertToDouble(this string inputString, double defaultValue = 0.0)
+        public static IResult<double> ConvertToDouble(
+            this string inputString, 
+            double defaultValue = 0.0, 
+            CultureInfo? cultureInfo = null)
         {
-            if (double.TryParse(inputString, out double result))
+            var numberStyle = NumberStyles.Any;
+            cultureInfo ??= CultureInfo.CreateSpecificCulture("en-GB");
+            if (double.TryParse(inputString, numberStyle, cultureInfo, out double result))
             {
                 return new ResultSuccess<double>(result);
             }

--- a/ConsoleExtension.Tests/System/ValueConverter/ConvertStringToDoubleTests.cs
+++ b/ConsoleExtension.Tests/System/ValueConverter/ConvertStringToDoubleTests.cs
@@ -1,0 +1,34 @@
+﻿using ConsoleExtension.Library.Converters;
+using ConsoleExtension.Library.Result;
+using FluentAssertions;
+
+namespace ConsoleExtension.Tests.System.ValueConverter
+{
+    public class ConvertStringToDoubleTests
+    {
+
+        [Fact]
+        public void ConvertToDouble_ShouldReturnSuccessValue1_WhenStringIs1()
+        {
+            // Arrange
+            string input = "1,1";
+            // Act
+            IResult<double> result = input.ConvertToDouble();
+            // Assert
+            result.Should().BeOfType(typeof(ResultSuccess<double>));
+            result.Value.Should().Be(1.1);
+        }
+
+        [Fact]
+        public void ConvertToDouble_ShouldReturnFailedValue0_WhenStringIsNotConvertableToDouble()
+        {
+            // Arrange
+            string input = "IAmNotConvertibleToDouble";
+            // Act
+            IResult<double> result = input.ConvertToDouble();
+            // Assert
+            result.Should().BeOfType(typeof(ResultFailed<double>));
+            result.Value.Should().Be(0);
+        }
+    }
+}

--- a/ConsoleExtension.Tests/System/ValueConverter/ConvertStringToDoubleTests.cs
+++ b/ConsoleExtension.Tests/System/ValueConverter/ConvertStringToDoubleTests.cs
@@ -1,6 +1,7 @@
 ﻿using ConsoleExtension.Library.Converters;
 using ConsoleExtension.Library.Result;
 using FluentAssertions;
+using System.Globalization;
 
 namespace ConsoleExtension.Tests.System.ValueConverter
 {
@@ -8,10 +9,22 @@ namespace ConsoleExtension.Tests.System.ValueConverter
     {
 
         [Fact]
-        public void ConvertToDouble_ShouldReturnSuccessValue1_WhenStringIs1()
+        public void ConvertToDouble_ShouldReturnSuccessValue1_WhenStringIs1AndCultureSwe()
         {
             // Arrange
             string input = "1,1";
+            CultureInfo culture = CultureInfo.CreateSpecificCulture("sv-SE");
+            // Act
+            IResult<double> result = input.ConvertToDouble(0,culture);
+            // Assert
+            result.Should().BeOfType(typeof(ResultSuccess<double>));
+            result.Value.Should().Be(1.1);
+        }
+        [Fact]
+        public void ConvertToDouble_ShouldReturnSuccessValue1_WhenStringIs1AndCultureDefault()
+        {
+            // Arrange
+            string input = "1.1";
             // Act
             IResult<double> result = input.ConvertToDouble();
             // Assert
@@ -29,6 +42,17 @@ namespace ConsoleExtension.Tests.System.ValueConverter
             // Assert
             result.Should().BeOfType(typeof(ResultFailed<double>));
             result.Value.Should().Be(0);
+        }
+        [Fact]
+        public void ConvertToDouble_ShouldReturnFailedValue999_WhenStringIsNotConvertableToDoubleAndDefaultSetTo999()
+        {
+            // Arrange
+            string input = "IAmNotConvertibleToDouble";
+            // Act
+            IResult<double> result = input.ConvertToDouble(999);
+            // Assert
+            result.Should().BeOfType(typeof(ResultFailed<double>));
+            result.Value.Should().Be(999);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
 # ConsoleExtension
 Extra functionality for the console
+* **Read** input from the console, with interface making it easier to mock.
+* **Write** to the console, with interface making it easier to mock.
+* **Convert** a string to integer, double, etc.
+* **Verify** the correctnes of an integer, double, etc against your business rules. 
+
+# How to
+## Read from the console
+**Read** input from the console, with interface making it easier to mock.
+
+```csharp
+    IReadData read = new ReadDataFromConsole();
+    string inputString = read.ReadData();
+```
+
+## Write to the console
+**Write** to the console, with interface making it easier to mock.
+```csharp
+    IWriteData write = new WriteDataToConsole();
+    write.WriteLine("Nice and pretty value... :)");
+```
+
+## Convert data
+**Integer**: 
+```csharp
+    IResult<int> result = "1".ConvertToInt();
+```
+
+**Double**
+```csharp
+    IResult<double> result = input.ConvertToDouble(); //Uses default culture: en-GB
+```
+```csharp
+    string input = "1,1";
+    double defaultValue = 1.1;
+    CultureInfo cultureSE = CultureInfo.CreateSpecificCulture("sv-SE");
+    IResult<double> result = input.ConvertToDouble(defaultValue,cultureSE);
+```
+### Examples
+```csharp
+    IResult<int> convertedInteger = inputString.ConvertToInt();
+    if (convertedInteger is IResultSuccess<int> resultInt)
+    {
+        write.WriteLine("Nice and pretty value... :)");
+        write.WriteLine(resultInt.Value.ToString());
+    }
+    else
+    {
+        write.WriteLine($"BAD result. Entered: {inputString} Defaulted to: {convertedInteger.Value}");
+        var errors = convertedInteger.ResultMessages;
+        foreach (var error in errors)
+        {
+            write.WriteLine(error);
+        }
+    }
+```
+
+## Verify data
+### Chain methods
+All Verify methods can be chained together. 
+**Note**: Evaluation continues even if first Verifymethod fails. All error-messages can be found in *ResultMessages*.
+
+### Verify returns
+**Returns ResultFailed():IResultFailed** if evaluation fails or if input is IResultFailed.
+**Returns ResultSuccess():IResultSuccess** if evaluation results to valid and input is IResultSuccess. 
+
+
+### Int
+**VerifyBelow**
+Verifies that the input value is _below_ specified value.
+```csharp
+int number = ResultSuccess(3);
+IResult<int> result = number.VerifyBelow(10);
+```
+**VerifyOver**
+Verifies that the input value is _over_ specified value.
+```csharp
+int number = ResultSuccess(10);
+IResult<int> result = number.VerifyOver(5);
+```
+
+### Examples
+```csharp
+    IResult<int> convertedIntegerVerified = inputString.ConvertToInt().VerifyBelow(10).VerifyOver(3);
+
+    if (convertedIntegerVerified is IResultSuccess<int> resultIntVerify)
+    {
+        write.WriteLine("Nice and pretty value... :)");
+        write.WriteLine(resultIntVerify.Value.ToString());
+    }
+    else
+    {
+        write.WriteLine($"BAD result. Entered: {inputString} Defaulted to: {convertedInteger.Value}");
+        var errors = convertedIntegerVerified.ResultMessages;
+        foreach (var error in errors)
+        {
+            write.WriteLine(error);
+        }
+    }
+```
+
+## IResult, IResultSuccess, IResultFailed


### PR DESCRIPTION
Add the ability to convert from string to double.

Worth noting is the fact that the conversion is locality sensitive.
This means that for a decimalseparator a ',' (comma), since I live in
Sweden, was needed to make an accepted conversion. And not a '.'.
https://docs.microsoft.com/en-us/dotnet/api/system.double.tryparse?view=net-6.0

This implementation lacks the numberstyles feature
https://docs.microsoft.com/en-us/dotnet/api/system.globalization.numberstyles?view=net-6.0

Fixes #8
