### PR TITLE
refactor: Move common Verify code to a baseclass

### DIFF
--- a/ConsoleExtension.Library/Rules/BaseVerify.cs
+++ b/ConsoleExtension.Library/Rules/BaseVerify.cs
@@ -1,0 +1,23 @@
+﻿using ConsoleExtension.Library.Result;
+
+namespace ConsoleExtension.Library.Rules
+{
+    public class BaseVerify
+    {
+        public static IResult<T> VerifyValue<T>(
+            IResult<T> valueToCompare,
+            bool isCompareValueSuccess,
+            string messageOnFailure)
+        {
+            if (isCompareValueSuccess == false)
+            {
+                valueToCompare.AddResultMessage($"Rule violation: {messageOnFailure}");
+            }
+            if (valueToCompare is IResultSuccess<int> && isCompareValueSuccess)
+            {
+                return valueToCompare.ConvertToSuccess();
+            }
+            return valueToCompare.ConvertToFail();
+        }
+    }
+}

--- a/ConsoleExtension.Library/Rules/VerifyIntBelowValue.cs
+++ b/ConsoleExtension.Library/Rules/VerifyIntBelowValue.cs
@@ -8,15 +8,8 @@ namespace ConsoleExtension.Library.Rules
         public static IResult<int> VerifyBelow(this IResult<int> valueToCompare, int compareAgainst)
         {
             bool IsBelowValue = valueToCompare.Value < compareAgainst;
-            if (IsBelowValue == false)
-            {
-                valueToCompare.AddResultMessage($"Rule violation: {valueToCompare.Value} is not below {compareAgainst}.");
-            }
-            if (valueToCompare is IResultSuccess<int> && IsBelowValue)
-            {
-                return valueToCompare.ConvertToSuccess();
-            }
-            return valueToCompare.ConvertToFail();
+            string errorMessage = $"{valueToCompare.Value} is not below {compareAgainst}.";
+            return BaseVerify.VerifyValue(valueToCompare, IsBelowValue, errorMessage);
         }
     }
 }

--- a/ConsoleExtension.Library/Rules/VerifyIntOverValue.cs
+++ b/ConsoleExtension.Library/Rules/VerifyIntOverValue.cs
@@ -7,15 +7,8 @@ namespace ConsoleExtension.Library.Rules
         public static IResult<int> VerifyOver(this IResult<int> valueToCompare, int compareAgainst)
         {
             bool IsOverValue = valueToCompare.Value > compareAgainst;
-            if (IsOverValue == false)
-            {
-                valueToCompare.AddResultMessage($"Rule violation: {valueToCompare.Value} is not over {compareAgainst}.");
-            }
-            if (valueToCompare is IResultSuccess<int> && IsOverValue)
-            {
-                return valueToCompare.ConvertToSuccess();
-            }
-            return valueToCompare.ConvertToFail();
+            string errorMessage = $"{valueToCompare.Value} is not over {compareAgainst}.";
+            return BaseVerify.VerifyValue(valueToCompare, IsOverValue, errorMessage);
         }
     }
 }


### PR DESCRIPTION
All verify classes have the same codestructure. So I moved it to a
baseclass to make it easier to implement and reduce risk of bugs.

The verify-classes now only have to call the BaseVerify.VerifyValue()

Sadly you cannot inherit BaseVerify from the Verify-classes, so the
BaseVerify.VerifyValue() is standalone and static.

Fixes #11
