### PR TITLE
fix: Fix one resultmessage when multi Verify fails

### DIFF
--- a/ConsoleExtProgram/Program.cs
+++ b/ConsoleExtProgram/Program.cs
@@ -37,8 +37,10 @@ else
 
 // ************ //
 // Verify rules //
+int[] myCollection = { 1, 2, 3, 4 };
 IResult<int> convertedIntegerVerified = inputString
     .ConvertToInt()
+    .Verify(x => Array.Exists(myCollection,z => z == x),"Not Contained in collection")
     .Verify(x => x > 6, "Value is not above 6")
     .Verify(x => x < 10, "value is not under 10");
 IResult<int> test0 = inputString.ConvertToInt().Verify(x => x > 6).Verify(x => x < 10);

--- a/ConsoleExtension.Library/VerifyValue/VerifyResultValue.cs
+++ b/ConsoleExtension.Library/VerifyValue/VerifyResultValue.cs
@@ -6,20 +6,15 @@ namespace ConsoleExtension.Library.VerifyValue
     {
         public static IResult<T> Verify<T>(this IResult<T> valueToVerify, Func<T,bool> evaluate, string messageOnFail = "")
         {
-            if (valueToVerify.IsSuccessful == false)
-            {
-                return valueToVerify;
-            }
-
             bool havePassedTest = evaluate.Invoke(valueToVerify.Value);
 
-            if (havePassedTest == true)
+            if (havePassedTest == true && valueToVerify.IsSuccessful == true)
             {
                 valueToVerify.SetToSuccess();
                 return valueToVerify;
             }
 
-            if (string.IsNullOrWhiteSpace(messageOnFail) == false)
+            if (havePassedTest == false && string.IsNullOrWhiteSpace(messageOnFail) == false)
             {
                 valueToVerify.AddResultMessage(messageOnFail);
             }

--- a/ConsoleExtension.Tests/System/VerifyValue/VerifyResultValueTests.cs
+++ b/ConsoleExtension.Tests/System/VerifyValue/VerifyResultValueTests.cs
@@ -94,4 +94,31 @@ public class VerifyResultValueTests
         // Assert
         resultValue.ResultMessages.Should().HaveCount(0);
     }
+
+
+    [Fact]
+    public void Verify_ShouldReturnResultWithTwoMessages_WhenEvaluateIsFalseAndInputResultWithOneMessage()
+    {
+        // Arrange
+        var resultClass = new ResultFactory<int>().Create(0, 5, true);
+        var result1 = resultClass.Verify(x => false, "We have error 1");
+        // Act
+        var resultValue = result1.Verify(x => false, "We have error 2");
+        // Assert
+        resultValue.ResultMessages.Should().HaveCount(2);
+    }
+
+
+    [Fact]
+    public void Verify_ShouldReturnResultNoNewMessages_WhenEvaluateIsTrueAndInputResultIsFalse()
+    {
+        // Arrange
+        var resultClass = new ResultFactory<int>().Create(0, 5, false);
+        // Act
+        var resultValue = resultClass.Verify(x => true, "We have error");
+        // Assert
+        resultValue.ResultMessages.Should().HaveCount(0);
+        resultValue.IsSuccessful.Should().BeFalse();
+    }
+
 }


### PR DESCRIPTION
To make sure a message was created, I removed the guardclaus in the
function. Therefore I hade to add some extra checks further down in
the method.

Fixes #14
