### PR TITLE
feat: Add StringModifier, w/ Padding and Truncate

### DIFF
--- a/ConsoleExtProgram/Program.cs
+++ b/ConsoleExtProgram/Program.cs
@@ -2,11 +2,14 @@
 using ConsoleExtension.Library.Result;
 using ConsoleExtension.Library.ReadWrite;
 using ConsoleExtension.Library.VerifyValue;
+using ConsoleExtension.Library.DataModifiers;
 
 (IWriteData consoleWrite, IReadData consoleRead) = Init();
-string inputValue = GetValueFromUser(consoleRead);
-ConvertValues(inputValue, consoleWrite);
-VerifyValue(inputValue, consoleWrite);
+
+//string inputValue = GetValueFromUser(consoleRead);
+//ConvertValues(inputValue, consoleWrite);
+//VerifyValue(inputValue, consoleWrite);
+StringModifyDemo(consoleWrite);
 
 static (IWriteData, IReadData) Init()
 {
@@ -77,4 +80,29 @@ static void PrintResult<T>(IResult<T> result, string userInput, IWriteData write
             write.WriteLine($"{prefix}{error}{suffix}");
         }
     }
+}
+
+
+
+static void StringModifyDemo(IWriteData write)
+{
+    string[] names = { "Adam", "Bridgette", "Carla", "Daniel", "Ebenezer", "Francine", "George" };
+    decimal[] hours = { 40, 6.667m, 40.39m, 82, 40.333m, 80, 16.75m };
+
+    StringModifier stringModifier = new();
+
+    for (int i = 0; i < names.Length; i++)
+    {
+        string name = stringModifier.Padding(names[i], Alignment.LEFT, 15);
+        string hour = stringModifier.Padding(hours[i], Alignment.RIGHT, 5);
+        write.WriteLine(name + hour);
+    }
+
+
+    string myString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque ut " +
+        "volutpat enim. Cras sollicitudin quam et ligula aliquet, sed commodo felis dapibus.";
+    write.WriteLine("");
+    write.WriteLine(stringModifier.Padding("Truncate",Alignment.CENTER,20,'*'));
+    write.WriteLine(stringModifier.Truncate(myString, 11));
+
 }

--- a/ConsoleExtension.Library/DataModifiers/Alignment.cs
+++ b/ConsoleExtension.Library/DataModifiers/Alignment.cs
@@ -1,0 +1,8 @@
+﻿namespace ConsoleExtension.Library.DataModifiers;
+
+public enum Alignment
+{
+    LEFT = -1,
+    CENTER = 0,
+    RIGHT = 1,
+}

--- a/ConsoleExtension.Library/DataModifiers/StringModifier.cs
+++ b/ConsoleExtension.Library/DataModifiers/StringModifier.cs
@@ -1,0 +1,65 @@
+﻿namespace ConsoleExtension.Library.DataModifiers;
+
+public class StringModifier
+{
+    /// <summary>
+    /// Shortens the string to maximum of length
+    /// </summary>
+    /// <param name="inputString">The string to be transformed</param>
+    /// <param name="length">The maximum length of the string. -1 == do not truncate</param>
+    /// <returns>The shorter string</returns>
+    public string Truncate(string inputString, int length)
+    {
+        return length >= 0 && inputString.Length >= length ? inputString[..length] : inputString;
+    }
+
+    /// <summary>
+    /// Adds padding before and after the provided string.
+    /// </summary>
+    /// <param name="data">Add padding to this string</param>
+    /// <param name="alignment">-1 == left, 0 == center, 1 == right</param>
+    /// <param name="columnWidth">The width of the final string</param>
+    /// <param name="spaceFill">Character to fill with</param>
+    /// <returns>A padded string</returns>
+    public string Padding(string data, Alignment alignment = Alignment.LEFT, int columnWidth = 15, char spaceFill = '.')
+    {
+        int widthToFill = columnWidth - data.Length;
+        (int left, int right) padding = PaddingWidth(alignment, widthToFill);
+
+        data = new string(spaceFill, padding.left) + data + new string(spaceFill, padding.right);
+        data = Truncate(data, columnWidth);
+
+        return data;
+    }
+
+    public string Padding<T>(T data, Alignment alignment = Alignment.LEFT, int columnWidth = 15, char spaceFill = '.')
+    {
+        string value = data?.ToString() ?? string.Empty;
+        return Padding(value, alignment, columnWidth, spaceFill);
+    }
+    private static (int left, int right) PaddingWidth(Alignment alignment, int widthToFill)
+    {
+        int leftWidth = 0;
+        int rightWidth = 0;
+
+        switch (alignment)
+        {
+            case Alignment.LEFT:
+                rightWidth = widthToFill;
+                break;
+            case Alignment.CENTER:
+                leftWidth = widthToFill / 2;
+                rightWidth = widthToFill - leftWidth;
+                break;
+            case Alignment.RIGHT:
+                leftWidth = widthToFill;
+                break;
+            default:
+                break;
+        }
+
+        leftWidth = leftWidth < 0 ? 0 : leftWidth;
+        rightWidth = rightWidth < 0 ? 0 : rightWidth;
+        return (leftWidth, rightWidth);
+    }
+}

--- a/ConsoleExtension.Tests/System/DataModifiers/StringModifierTests.cs
+++ b/ConsoleExtension.Tests/System/DataModifiers/StringModifierTests.cs
@@ -1,0 +1,89 @@
+﻿using ConsoleExtension.Library.DataModifiers;
+using FluentAssertions;
+namespace ConsoleExtension.Tests.System.DataModifiers;
+
+public class StringModifierTests
+{
+
+    [Fact]
+    public void Truncate_ShouldReturnString1234_WhenInputString_123456789_AndMaxLength4()
+    {
+        // Arrange
+        StringModifier sut = new();
+        string testString = "123456789";
+        // Act
+        String result = sut.Truncate(testString, 4);
+        // Assert
+        result.Should().Be("1234");
+    }
+
+    [Fact]
+    public void Truncate_ShouldReturnString12_WhenInputString_12_AndMaxLength4()
+    {
+        // Arrange
+        StringModifier sut = new();
+        string testString = "12";
+        // Act
+        String result = sut.Truncate(testString, 4);
+        // Assert
+        result.Should().Be("12");
+    }
+
+    [Fact]
+    public void Padding_ShouldReturnStringxxx12_WhenInputString_12_Width5FillWithxAlign1()
+    {
+        // Arrange
+        StringModifier sut = new();
+        string testString = "12";
+        int width = 5;
+        char fillChar = 'x';
+        Alignment alignment = Alignment.RIGHT;
+        // Act
+        String result = sut.Padding(testString, alignment, width, fillChar);
+        // Assert
+        result.Should().Be("xxx12");
+    }
+    [Fact]
+    public void Padding_ShouldReturnStringx12xx_WhenInputString_12_Width5FillWithxAlign0()
+    {
+        // Arrange
+        StringModifier sut = new();
+        string testString = "12";
+        int width = 5;
+        char fillChar = 'x';
+        Alignment alignment = Alignment.CENTER;
+        // Act
+        String result = sut.Padding(testString, alignment, width, fillChar);
+        // Assert
+        result.Should().Be("x12xx");
+    }
+    [Fact]
+    public void Padding_ShouldReturnString12xxx_WhenInputString_12_Width5FillWithxAlignM1()
+    {
+        // Arrange
+        StringModifier sut = new();
+        string testString = "12";
+        int width = 5;
+        char fillChar = 'x';
+        Alignment alignment = Alignment.LEFT;
+        // Act
+        String result = sut.Padding(testString, alignment, width, fillChar);
+        // Assert
+        result.Should().Be("12xxx");
+    }
+
+    [Fact]
+    public void Padding_ShouldReturnStringxxxxx_WhenInputString_null_Width5FillWithxAlignLeft()
+    {
+        // Arrange
+        StringModifier sut = new();
+        int? testValue = null;
+        int width = 5;
+        char fillChar = 'x';
+        Alignment alignment = Alignment.LEFT;
+        // Act
+        String result = sut.Padding(testValue, alignment, width, fillChar);
+        // Assert
+        result.Should().Be("xxxxx");
+    }
+}


### PR DESCRIPTION
Add StringModifier class with the methods Padding and Truncate.
Padding uses the method Truncate, hence commiting both at the same time.

With Padding you can add extra characters before and/or after
your string in order to make it look better aligned.
"Hello" => "Hello..." (Padded with '.' to give it a width of 8)

Truncate cuts of the remaning characters in the string if it excedes
the max length.
